### PR TITLE
Use "online" webhook for staffing reqs.

### DIFF
--- a/base/api/configmap.yaml
+++ b/base/api/configmap.yaml
@@ -23,6 +23,7 @@ items:
           visiting_application: {{.DISCORD_WEBHOOK_VISITING_APPLICATION}}
           seniorstaff: {{.DISCORD_WEBHOOK_SENIORSTAFF}}
           online: {{.DISCORD_WEBHOOK_ONLINE}}
+          staffing_request: {{.DISCORD_WEBHOOK_ONLINE}}
           default: {{.DISCORD_WEBHOOK_DEFAULT}}
         client_id: {{.DISCORD_CLIENT_ID}}
         client_secret: {{.DISCORD_CLIENT_SECRET}}

--- a/base/api/configmap.yaml
+++ b/base/api/configmap.yaml
@@ -23,7 +23,7 @@ items:
           visiting_application: {{.DISCORD_WEBHOOK_VISITING_APPLICATION}}
           seniorstaff: {{.DISCORD_WEBHOOK_SENIORSTAFF}}
           online: {{.DISCORD_WEBHOOK_ONLINE}}
-          staffing_request: {{.DISCORD_WEBHOOK_ONLINE}}
+          staffing_request: {{.DISCORD_WEBHOOK_EVENTS}}
           default: {{.DISCORD_WEBHOOK_DEFAULT}}
         client_id: {{.DISCORD_CLIENT_ID}}
         client_secret: {{.DISCORD_CLIENT_SECRET}}


### PR DESCRIPTION
Rather than the default webhook. We could make another webhook for it, but it'd likely be posting to the same channel anyway.