### PR TITLE
Increase API resources

### DIFF
--- a/base/api/deployment.yaml
+++ b/base/api/deployment.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 100Mi
+            memory: 500Mi
           limits:
             cpu: 250m
-            memory: 500Mi
+            memory: 1Gi
       volumes:
       - name: config
         emptyDir: {}


### PR DESCRIPTION
Trying to keep the pod from being OOM-killed. Optimally we overshoot the required resources and then incrementally bring it back down to a comfortable level.